### PR TITLE
Renamed to reserved name

### DIFF
--- a/src/httpdocs/manifest.json
+++ b/src/httpdocs/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "MSP Manager",
-    "short_name": "MSP Manager",
+    "name": "MSP-Manager",
+    "short_name": "MSP-Manager",
     "description": "A web-based companion app to more easily manage partners in Microsoft PartnerCenter.",
     "start_url": "/",
     "display": "standalone",


### PR DESCRIPTION
Changed the name in the manifest to MSP-Manager as MSP Manager was already reserved in the store.